### PR TITLE
fix: detectBlockShortText returns zero probabilities for all languages (issue #40)

### DIFF
--- a/src/main/java/com/optimaize/langdetect/LanguageDetectorImpl.java
+++ b/src/main/java/com/optimaize/langdetect/LanguageDetectorImpl.java
@@ -229,7 +229,7 @@ public final class LanguageDetectorImpl implements LanguageDetector {
             }
         }
         for (int i=0; i<prob.length; ++i) {
-        	prob[i] *= Math.pow(weight + langProbMap[i], 1);
+        	prob[i] *= Math.pow(weight + langProbMap[i], count);
         }
         return true;
     }

--- a/src/main/java/com/optimaize/langdetect/LanguageDetectorImpl.java
+++ b/src/main/java/com/optimaize/langdetect/LanguageDetectorImpl.java
@@ -21,7 +21,6 @@ import java.util.*;
  * @author Elmer Garduno
  */
 public final class LanguageDetectorImpl implements LanguageDetector {
-
     private static final Logger logger = LoggerFactory.getLogger(LanguageDetectorImpl.class);
 
     /**
@@ -159,6 +158,7 @@ public final class LanguageDetectorImpl implements LanguageDetector {
         double alpha = this.alpha; //TODO I don't understand what this does.
         for (Map.Entry<String, Integer> gramWithCount : ngrams.entrySet()) {
             updateLangProb(prob, gramWithCount.getKey(), gramWithCount.getValue(), alpha);
+            if (Util.normalizeProb(prob) > CONV_THRESHOLD) break; //this break ensures that we quit the loop before all probabilities reach 0
         }
         Util.normalizeProb(prob);
         if (logger.isDebugEnabled()) logger.debug("==> " + sortProbability(prob));
@@ -181,7 +181,7 @@ public final class LanguageDetectorImpl implements LanguageDetector {
                 int r = rand.nextInt(ngrams.size());
                 updateLangProb(prob, ngrams.get(r), 1, alpha);
                 if (i % 5 == 0) {
-                    if (Util.normalizeProb(prob) > CONV_THRESHOLD) break; //this looks like an optimization to return quickly when sure. TODO document what's the plan.
+                    if (Util.normalizeProb(prob) > CONV_THRESHOLD) break; //this break ensures that we quit the loop before all probabilities reach 0
                     if (logger.isTraceEnabled()) logger.trace("> " + sortProbability(prob));
                 }
             }
@@ -218,7 +218,6 @@ public final class LanguageDetectorImpl implements LanguageDetector {
         if (langProbMap==null) {
             return false;
         }
-
         if (logger.isTraceEnabled()) logger.trace(ngram + "(" + Util.unicodeEncode(ngram) + "):" + Util.wordProbToString(langProbMap, ngramFrequencyData.getLanguageList()));
 
         double weight = alpha / BASE_FREQ;
@@ -230,9 +229,7 @@ public final class LanguageDetectorImpl implements LanguageDetector {
             }
         }
         for (int i=0; i<prob.length; ++i) {
-            for (int amount=0; amount<count; amount++) {
-                prob[i] *= (weight + langProbMap[i]);
-            }
+        	prob[i] *= Math.pow(weight + langProbMap[i], 1);
         }
         return true;
     }

--- a/src/test/java/com/optimaize/langdetect/DataLanguageDetectorImplTest.java
+++ b/src/test/java/com/optimaize/langdetect/DataLanguageDetectorImplTest.java
@@ -44,6 +44,7 @@ public class DataLanguageDetectorImplTest {
         assertEquals(detector.getProbabilities(text("Dit is een Nederlandse tekst.")).get(0).getLocale().getLanguage(), "nl");
         assertEquals(detector.getProbabilities(text("Dies ist eine deutsche Text")).get(0).getLocale().getLanguage(), "de");
         assertEquals(detector.getProbabilities(text("សព្វវចនាធិប្បាយសេរីសម្រាប់អ្នកទាំងអស់គ្នា។" +"នៅក្នុងវិគីភីឌាភាសាខ្មែរឥឡូវនេះមាន ១១៩៨រូបភាព សមាជិក១៥៣៣៣នាក់ និងមាន៤៥៨៣អត្ថបទ។")).get(0).getLocale().getLanguage(), "km");
+        assertEquals(detector.getProbabilities(text("Европа не трябва да стартира нов конкурентен маратон и изход с приватизация")).get(0).getLocale().getLanguage(), "bg");
     }
 
     private CharSequence text(CharSequence text) {


### PR DESCRIPTION
* added an example that triggers this bug to `DataLanguageDetectorImplTest`.
* break `detectBlockShortText` once `CONV_THRESHOLD` has been reached.
* use `Math.pow` rather than a loop to compute `prob[i] *= prob[i]^{counts}`.