### PR TITLE
Changed Guava dependency from 18.0 to 14.0.1 to make it compatible with Apache Spark

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -228,7 +228,7 @@
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>18.0</version>
+            <version>14.0.1</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/src/main/java/com/optimaize/langdetect/i18n/LdLocale.java
+++ b/src/main/java/com/optimaize/langdetect/i18n/LdLocale.java
@@ -2,6 +2,8 @@ package com.optimaize.langdetect.i18n;
 
 import com.google.common.base.Optional;
 import com.google.common.base.Splitter;
+import com.google.common.collect.Lists;
+
 import org.jetbrains.annotations.NotNull;
 
 import java.util.List;
@@ -74,7 +76,7 @@ public final class LdLocale {
         Optional<String> script = null;
         Optional<String> region = null;
 
-        List<String> strings = Splitter.on('-').splitToList(string);
+        List<String> strings = Lists.newArrayList(Splitter.on('-').split(string));
         for (int i=0; i<strings.size(); i++) {
             String chunk = strings.get(i);
             if (i==0) {

--- a/src/test/java/com/optimaize/langdetect/ngram/NgramExtractorTest.java
+++ b/src/test/java/com/optimaize/langdetect/ngram/NgramExtractorTest.java
@@ -63,7 +63,8 @@ public class NgramExtractorTest {
     public void stressTestAlgo2() {
         NgramExtractor ngramExtractor = NgramExtractor.gramLengths(1, 2, 3);
         String text = "Foo bar hello world and so on nana nunu dada dudu asdf asdf akewf köjvnawer aisdfj awejfr iajdsöfj ewi adjsköfjwei ajsdökfj ief asd";
-        Stopwatch stopwatch = Stopwatch.createStarted();
+        Stopwatch stopwatch = new Stopwatch();
+        stopwatch.start();
         for (int i=0; i<100000; i++) {
             ngramExtractor.extractGrams(text);
         }

--- a/src/test/java/com/optimaize/langdetect/ngram/OldNgramExtractorTest.java
+++ b/src/test/java/com/optimaize/langdetect/ngram/OldNgramExtractorTest.java
@@ -33,7 +33,8 @@ public class OldNgramExtractorTest {
     @Test
     public void stressTestAlgo1() {
         String text = "Foo bar hello world and so on nana nunu dada dudu asdf asdf akewf köjvnawer aisdfj awejfr iajdsöfj ewi adjsköfjwei ajsdökfj ief asd";
-        Stopwatch stopwatch = Stopwatch.createStarted();
+        Stopwatch stopwatch = new Stopwatch();
+        stopwatch.start();
         for (int i=0; i<100000; i++) {
             OldNgramExtractor.extractNGrams(text, null); //2.745s
         }


### PR DESCRIPTION
[Apache Spark](https://spark.apache.org/) provides already a previous version of the Google Guava library. This makes the two tools difficult to integrate (cfr. [this StackOverflow question](http://stackoverflow.com/questions/34209329/guava-version-while-using-spark-shell)).

In this version of the repo I changed the Guava dependency and adjusted the rest of the code accordingly.

I know that switching to a previous version of a library is normally not a good idea, so I understand if you don't accept my pull request.

Hope this helps.