### PR TITLE
Better validation of language priorities passed

### DIFF
--- a/src/main/java/com/optimaize/langdetect/LanguageDetectorBuilder.java
+++ b/src/main/java/com/optimaize/langdetect/LanguageDetectorBuilder.java
@@ -145,9 +145,10 @@ public class LanguageDetectorBuilder {
 
 
     /**
-     * TODO document exactly. Also explain how it influences the results.
-     * Maybe check for unsupported languages at some point, or not, but document whether it does throw or ignore.
-     * String key = language, Double value = priority (probably 0-1).
+     * Accepts a list of relative a priori probabilities of each language.
+     * The values passed have to be nonnegative. Passing a zero for a language (or not passing it at all)
+     * means this language will never be returned by detection.
+     * Languages that are not on profile list are ignored.
      */
     public LanguageDetectorBuilder languagePriorities(@Nullable Map<LdLocale, Double> langWeightingMap) {
         this.langWeightingMap = langWeightingMap;

--- a/src/main/java/com/optimaize/langdetect/cybozu/util/Util.java
+++ b/src/main/java/com/optimaize/langdetect/cybozu/util/Util.java
@@ -120,12 +120,13 @@ public class Util {
             LdLocale lang = langlist.get(i);
             if (langWeightingMap.containsKey(lang)) {
                 double p = langWeightingMap.get(lang);
-                assert p>=0 : "Prior probability must be non-negative!";
+                if (p < 0 || Double.isNaN(p)) throw new IllegalArgumentException("Prior probability must be non-negative!");
                 priorMap[i] = p;
                 sump += p;
             }
         }
-        assert sump > 0 : "Sum must be greater than zero!";
+        if(sump <= 0 || Double.isNaN(sump)) throw new IllegalArgumentException("Sum of probabilities must be greater than zero!");
+        if(Double.isInfinite(sump)) throw new IllegalArgumentException("Sum of probabilities must be finite!");
         for (int i=0;i<priorMap.length;++i) priorMap[i] /= sump;
         return priorMap;
     }

--- a/src/test/java/com/optimaize/langdetect/LanguageDetectorBuilderTest.java
+++ b/src/test/java/com/optimaize/langdetect/LanguageDetectorBuilderTest.java
@@ -1,0 +1,81 @@
+package com.optimaize.langdetect;
+
+import com.optimaize.langdetect.i18n.LdLocale;
+import com.optimaize.langdetect.ngram.NgramExtractors;
+import com.optimaize.langdetect.profiles.LanguageProfile;
+import com.optimaize.langdetect.profiles.LanguageProfileReader;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.Assert.*;
+
+/**
+ * Created by Administrator on 2017-07-27.
+ */
+public class LanguageDetectorBuilderTest {
+    private static List<LanguageProfile> languageProfiles;
+
+    @BeforeClass
+    public static void setUp() throws Exception {
+        languageProfiles = new LanguageProfileReader().readAllBuiltIn();
+    }
+
+    @Test
+    public void languagePrioritiesEmptyShouldNotThrow()  {
+        Map<LdLocale, Double> priorityMap = new HashMap<LdLocale, Double>();
+        LanguageDetector languageDetector = LanguageDetectorBuilder.create(NgramExtractors.standard())
+                .withProfiles(languageProfiles)
+                .languagePriorities(priorityMap)
+                .build();
+    }
+    @Test
+    public void languagePrioritiesShouldNotThrow()  {
+        Map<LdLocale, Double> priorityMap = new HashMap<LdLocale, Double>();
+        priorityMap.put(LdLocale.fromString("en"),1.0);
+        LanguageDetector languageDetector = LanguageDetectorBuilder.create(NgramExtractors.standard())
+                .withProfiles(languageProfiles)
+                .languagePriorities(priorityMap)
+                .build();
+    }
+    @Test(expected = IllegalArgumentException.class)
+    public void languagePrioritiesNegativeShouldThrow()  {
+        Map<LdLocale, Double> priorityMap = new HashMap<LdLocale, Double>();
+        priorityMap.put(LdLocale.fromString("en"),-1.0);
+        LanguageDetector languageDetector = LanguageDetectorBuilder.create(NgramExtractors.standard())
+                .withProfiles(languageProfiles)
+                .languagePriorities(priorityMap)
+                .build();
+    }
+    @Test(expected = IllegalArgumentException.class)
+    public void languagePrioritiesOnlyUnknownLocalesShouldThrow()  {
+        Map<LdLocale, Double> priorityMap = new HashMap<LdLocale, Double>();
+        priorityMap.put(LdLocale.fromString("xx"),1.0);
+        LanguageDetector languageDetector = LanguageDetectorBuilder.create(NgramExtractors.standard())
+                .withProfiles(languageProfiles)
+                .languagePriorities(priorityMap)
+                .build();
+    }
+    @Test(expected = IllegalArgumentException.class)
+    public void languagePrioritiesAllZerosShouldThrow()  {
+        Map<LdLocale, Double> priorityMap = new HashMap<LdLocale, Double>();
+        priorityMap.put(LdLocale.fromString("en"),0.0);
+        LanguageDetector languageDetector = LanguageDetectorBuilder.create(NgramExtractors.standard())
+                .withProfiles(languageProfiles)
+                .languagePriorities(priorityMap)
+                .build();
+    }
+    @Test(expected = IllegalArgumentException.class)
+    public void languagePrioritiesNANShouldThrow()  {
+        Map<LdLocale, Double> priorityMap = new HashMap<LdLocale, Double>();
+        priorityMap.put(LdLocale.fromString("en"),Double.NaN);
+        LanguageDetector languageDetector = LanguageDetectorBuilder.create(NgramExtractors.standard())
+                .withProfiles(languageProfiles)
+                .languagePriorities(priorityMap)
+                .build();
+    }
+}


### PR DESCRIPTION
Asserts are usually disabled in production environments, and passing invalid values results in misleading error messages.
Should fix https://github.com/optimaize/language-detector/issues/24, based on user research provided there.