### PR TITLE
Java 8 upgrade

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>com.optimaize.languagedetector</groupId>
-    <artifactId>language-detector</artifactId>
+    <artifactId>language-detector-java-8</artifactId>
     <name>language-detector</name>
     <version>0.7-SNAPSHOT</version>
     <packaging>jar</packaging>
@@ -23,8 +23,8 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <compiler.source>1.7</compiler.source>
-        <compiler.target>1.7</compiler.target>
+        <compiler.source>1.8</compiler.source>
+        <compiler.target>1.8</compiler.target>
     </properties>
 
     <developers>

--- a/src/main/java/com/optimaize/langdetect/LanguageDetector.java
+++ b/src/main/java/com/optimaize/langdetect/LanguageDetector.java
@@ -16,10 +16,10 @@
 
 package com.optimaize.langdetect;
 
-import com.google.common.base.Optional;
 import com.optimaize.langdetect.i18n.LdLocale;
 
 import java.util.List;
+import java.util.Optional;
 
 /**
  * Guesses the language of an input string or text.

--- a/src/main/java/com/optimaize/langdetect/LanguageDetectorBuilder.java
+++ b/src/main/java/com/optimaize/langdetect/LanguageDetectorBuilder.java
@@ -16,16 +16,12 @@
 
 package com.optimaize.langdetect;
 
-import com.google.common.base.Optional;
 import com.optimaize.langdetect.i18n.LdLocale;
 import com.optimaize.langdetect.ngram.NgramExtractor;
 import com.optimaize.langdetect.profiles.LanguageProfile;
+import java.util.*;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
-
-import java.util.HashSet;
-import java.util.Map;
-import java.util.Set;
 
 
 /**
@@ -43,7 +39,7 @@ public class LanguageDetectorBuilder {
     private final NgramExtractor ngramExtractor;
 
     private double alpha = ALPHA_DEFAULT;
-    private Optional<Long> seed = Optional.absent();
+    private Optional<Long> seed = Optional.empty();
     private int shortTextAlgorithm = 50;
     private double prefixFactor = 1.0d;
     private double suffixFactor = 1.0d;

--- a/src/main/java/com/optimaize/langdetect/LanguageDetectorImpl.java
+++ b/src/main/java/com/optimaize/langdetect/LanguageDetectorImpl.java
@@ -17,7 +17,6 @@
 package com.optimaize.langdetect;
 
 import com.optimaize.langdetect.cybozu.util.Util;
-import com.google.common.base.Optional;
 import com.optimaize.langdetect.i18n.LdLocale;
 import com.optimaize.langdetect.ngram.NgramExtractor;
 import org.jetbrains.annotations.NotNull;
@@ -135,13 +134,13 @@ public final class LanguageDetectorImpl implements LanguageDetector {
     public Optional<LdLocale> detect(CharSequence text) {
         List<DetectedLanguage> probabilities = getProbabilities(text);
         if (probabilities.isEmpty()) {
-            return Optional.absent();
+            return Optional.empty();
         } else {
             DetectedLanguage best = probabilities.get(0);
             if (best.getProbability() >= minimalConfidence) {
                 return Optional.of(best.getLocale());
             } else {
-                return Optional.absent();
+                return Optional.empty();
             }
         }
     }
@@ -194,7 +193,7 @@ public final class LanguageDetectorImpl implements LanguageDetector {
     private double[] detectBlockLongText(List<String> ngrams) {
         assert !ngrams.isEmpty();
         double[] langprob = new double[ngramFrequencyData.getLanguageList().size()];
-        Random rand = new Random(seed.or(DEFAULT_SEED));
+        Random rand = new Random(seed.orElse(DEFAULT_SEED));
         for (int t = 0; t < N_TRIAL; ++t) {
             double[] prob = initProbability();
             double alpha = this.alpha + (rand.nextGaussian() * ALPHA_WIDTH);

--- a/src/main/java/com/optimaize/langdetect/LanguageDetectorImpl.java
+++ b/src/main/java/com/optimaize/langdetect/LanguageDetectorImpl.java
@@ -73,11 +73,7 @@ public final class LanguageDetectorImpl implements LanguageDetector {
      */
     private static final long DEFAULT_SEED = 41L;
 
-    private static final Comparator<DetectedLanguage> PROBABILITY_SORTING_COMPARATOR = new Comparator<DetectedLanguage>() {
-        public int compare(DetectedLanguage a, DetectedLanguage b) {
-            return Double.compare(b.getProbability(), a.getProbability());
-        }
-    };
+    private static final Comparator<DetectedLanguage> PROBABILITY_SORTING_COMPARATOR = (a, b) -> Double.compare(b.getProbability(), a.getProbability());
 
     @NotNull
     private final NgramFrequencyData ngramFrequencyData;

--- a/src/main/java/com/optimaize/langdetect/cybozu/CommandLineInterface.java
+++ b/src/main/java/com/optimaize/langdetect/cybozu/CommandLineInterface.java
@@ -18,7 +18,6 @@ package com.optimaize.langdetect.cybozu;
 
 import com.optimaize.langdetect.frma.LangProfileWriter;
 import com.optimaize.langdetect.cybozu.util.LangProfile;
-import com.google.common.base.Optional;
 import com.optimaize.langdetect.DetectedLanguage;
 import com.optimaize.langdetect.LanguageDetector;
 import com.optimaize.langdetect.LanguageDetectorBuilder;
@@ -286,7 +285,7 @@ public class CommandLineInterface {
     private LanguageDetector makeDetector() throws IOException {
         double alpha = getParamDouble("alpha", DEFAULT_ALPHA);
         String profileDirectory = requireParamString("directory") + "/";
-        Optional<Long> seed = Optional.fromNullable(getParamLongOrNull("seed"));
+        Optional<Long> seed = Optional.ofNullable(getParamLongOrNull("seed"));
 
         List<LanguageProfile> languageProfiles = new LanguageProfileReader().readAll(new File(profileDirectory));
 

--- a/src/main/java/com/optimaize/langdetect/cybozu/CommandLineInterface.java
+++ b/src/main/java/com/optimaize/langdetect/cybozu/CommandLineInterface.java
@@ -241,7 +241,7 @@ public class CommandLineInterface {
 
                     TextObject textObject = textObjectFactory.forText(text);
                     Optional<LdLocale> lang = languageDetector.detect(textObject);
-                    if (!result.containsKey(correctLang)) result.put(correctLang, new ArrayList<String>());
+                    if (!result.containsKey(correctLang)) result.put(correctLang, new ArrayList<>());
                     if (lang.isPresent()) {
                         result.get(correctLang).add(lang.toString());
                     } else {
@@ -267,7 +267,7 @@ public class CommandLineInterface {
                         resultCount.put(detectedLang, 1);
                     }
                 }
-                int correct = resultCount.containsKey(lang)?resultCount.get(lang):0;
+                int correct = resultCount.getOrDefault(lang, 0);
                 double rate = correct / (double)count;
                 System.out.println(String.format("%s (%d/%d=%.2f): %s", lang, correct, count, rate, resultCount));
                 totalCorrect += correct;

--- a/src/main/java/com/optimaize/langdetect/cybozu/util/Util.java
+++ b/src/main/java/com/optimaize/langdetect/cybozu/util/Util.java
@@ -87,7 +87,7 @@ public class Util {
      */
     public static double normalizeProb(double[] prob) {
         double maxp = 0, sump = 0;
-        for(int i=0;i<prob.length;++i) sump += prob[i];
+        for(double aProb : prob) sump += aProb;
         for(int i=0;i<prob.length;++i) {
             double p = prob[i] / sump;
             if (maxp < p) maxp = p;

--- a/src/main/java/com/optimaize/langdetect/cybozu/util/Util.java
+++ b/src/main/java/com/optimaize/langdetect/cybozu/util/Util.java
@@ -98,14 +98,15 @@ public class Util {
 
 
     public static String wordProbToString(double[] prob, List<LdLocale> langlist) {
-        Formatter formatter = new Formatter();
-        for(int j=0;j<prob.length;++j) {
-            double p = prob[j];
-            if (p>=0.00001) {
-                formatter.format(" %s:%.5f", langlist.get(j), p);
+        try (Formatter formatter = new Formatter()) {
+            for(int j=0;j<prob.length;++j) {
+                double p = prob[j];
+                if (p>=0.00001) {
+                    formatter.format(" %s:%.5f", langlist.get(j), p);
+                }
             }
+            return formatter.toString();
         }
-        return formatter.toString();
     }
 
 

--- a/src/main/java/com/optimaize/langdetect/frma/GenProfile.java
+++ b/src/main/java/com/optimaize/langdetect/frma/GenProfile.java
@@ -23,7 +23,7 @@ import com.optimaize.langdetect.text.TextObject;
 import com.optimaize.langdetect.text.TextObjectFactory;
 
 import java.io.*;
-import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.zip.GZIPInputStream;
 
 /**
@@ -52,7 +52,7 @@ public class GenProfile {
             is = new BufferedInputStream(new FileInputStream(textFile));
             if (textFile.getName().endsWith(".gz")) is = new GZIPInputStream(is);
 
-            BufferedReader reader = new BufferedReader(new InputStreamReader(is, Charset.forName("UTF-8")));
+            BufferedReader reader = new BufferedReader(new InputStreamReader(is, StandardCharsets.UTF_8));
             String line;
             while ((line = reader.readLine()) != null) {
                 TextObject textObject = textObjectFactory.forText(" "+line+" ");

--- a/src/main/java/com/optimaize/langdetect/frma/LangProfileReader.java
+++ b/src/main/java/com/optimaize/langdetect/frma/LangProfileReader.java
@@ -19,7 +19,7 @@ package com.optimaize.langdetect.frma;
 import com.optimaize.langdetect.cybozu.util.LangProfile;
 
 import java.io.*;
-import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -54,7 +54,7 @@ public class LangProfileReader {
      */
 	public LangProfile read(InputStream inputStream) throws IOException {
 		StringBuilder buffer = new StringBuilder();
-        try (BufferedReader reader = new BufferedReader(new InputStreamReader(inputStream, Charset.forName("utf-8")))) {
+        try (BufferedReader reader = new BufferedReader(new InputStreamReader(inputStream, StandardCharsets.UTF_8))) {
             String line;
             while((line = reader.readLine()) != null) {
                 if (buffer.length() > 0) {

--- a/src/main/java/com/optimaize/langdetect/frma/LangProfileWriter.java
+++ b/src/main/java/com/optimaize/langdetect/frma/LangProfileWriter.java
@@ -19,7 +19,7 @@ package com.optimaize.langdetect.frma;
 import com.optimaize.langdetect.cybozu.util.LangProfile;
 
 import java.io.*;
-import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.Map;
 
 /**
@@ -36,7 +36,7 @@ public class LangProfileWriter {
      * @throws IOException
      */
 	public void write(LangProfile langProfile, OutputStream outputStream) throws IOException {
-		try (BufferedWriter writer = new BufferedWriter(new OutputStreamWriter(outputStream, Charset.forName("utf-8")))) {
+		try (BufferedWriter writer = new BufferedWriter(new OutputStreamWriter(outputStream, StandardCharsets.UTF_8))) {
             writer.write("{\"freq\":{");
             boolean first = true;
             for (Map.Entry<String, Integer> entry : langProfile.getFreq().entrySet()) {

--- a/src/main/java/com/optimaize/langdetect/i18n/LdLocale.java
+++ b/src/main/java/com/optimaize/langdetect/i18n/LdLocale.java
@@ -16,8 +16,8 @@
 
 package com.optimaize.langdetect.i18n;
 
-import com.google.common.base.Optional;
 import com.google.common.base.Splitter;
+import java.util.Optional;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.List;
@@ -106,8 +106,8 @@ public final class LdLocale {
             }
         }
         assert language != null;
-        if (script==null) script = Optional.absent();
-        if (region==null) region = Optional.absent();
+        if (script==null) script = Optional.empty();
+        if (region==null) region = Optional.empty();
         return new LdLocale(language, script, region);
     }
 

--- a/src/main/java/com/optimaize/langdetect/profiles/LanguageProfileBuilder.java
+++ b/src/main/java/com/optimaize/langdetect/profiles/LanguageProfileBuilder.java
@@ -21,7 +21,6 @@ import com.optimaize.langdetect.ngram.NgramExtractor;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.HashMap;
-import java.util.Iterator;
 import java.util.Map;
 
 /**
@@ -98,11 +97,7 @@ public class LanguageProfileBuilder {
      * If the builder already has this ngram, the given frequency is added to the current count.
      */
     public LanguageProfileBuilder addGram(String ngram, int frequency) {
-        Map<String, Integer> map = ngrams.get(ngram.length());
-        if (map==null) {
-            map = new HashMap<>();
-            ngrams.put(ngram.length(), map);
-        }
+        Map<String, Integer> map = ngrams.computeIfAbsent(ngram.length(), k -> new HashMap<>());
         Integer total = map.get(ngram);
         if (total==null) total = 0;
         total += frequency;
@@ -121,13 +116,7 @@ public class LanguageProfileBuilder {
 
     private void removeNgramsWithLessFrequency() {
         for (Map<String, Integer> map : ngrams.values()) {
-            Iterator<Map.Entry<String, Integer>> iterator = map.entrySet().iterator();
-            while (iterator.hasNext()) {
-                Map.Entry<String, Integer> next = iterator.next();
-                if (next.getValue() < minimalFrequency) {
-                    iterator.remove();
-                }
-            }
+            map.entrySet().removeIf(next -> next.getValue() < minimalFrequency);
         }
     }
 

--- a/src/main/java/com/optimaize/langdetect/profiles/LanguageProfileImpl.java
+++ b/src/main/java/com/optimaize/langdetect/profiles/LanguageProfileImpl.java
@@ -129,7 +129,7 @@ public final class LanguageProfileImpl implements LanguageProfile {
 
     @Override
     public int getNumGrams(int gramLength) {
-        if (gramLength<1) throw new IllegalArgumentException(""+gramLength);
+        if (gramLength<1) throw new IllegalArgumentException(String.valueOf(gramLength));
         Map<String, Integer> map = ngrams.get(gramLength);
         if (map==null) return 0;
         return map.size();

--- a/src/main/java/com/optimaize/langdetect/profiles/LanguageProfileReader.java
+++ b/src/main/java/com/optimaize/langdetect/profiles/LanguageProfileReader.java
@@ -152,12 +152,7 @@ public class LanguageProfileReader {
         if (!path.canRead()) {
             throw new IOException("Folder not readable: "+path);
         }
-        File[] listFiles = path.listFiles(new FileFilter() {
-            @Override
-            public boolean accept(File pathname) {
-                return looksLikeLanguageProfileFile(pathname);
-            }
-        });
+        File[] listFiles = path.listFiles(this::looksLikeLanguageProfileFile);
         if (listFiles == null) {
             throw new IOException("Failed reading from folder: " + path);
         }

--- a/src/main/java/com/optimaize/langdetect/profiles/LanguageProfileWriter.java
+++ b/src/main/java/com/optimaize/langdetect/profiles/LanguageProfileWriter.java
@@ -19,7 +19,7 @@ package com.optimaize.langdetect.profiles;
 import org.jetbrains.annotations.NotNull;
 
 import java.io.*;
-import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.Map;
 
 /**
@@ -38,7 +38,7 @@ public class LanguageProfileWriter {
      * @throws java.io.IOException
      */
     public void write(@NotNull LanguageProfile languageProfile, @NotNull OutputStream outputStream) throws IOException {
-        try (BufferedWriter writer = new BufferedWriter(new OutputStreamWriter(outputStream, Charset.forName("utf-8")))) {
+        try (BufferedWriter writer = new BufferedWriter(new OutputStreamWriter(outputStream, StandardCharsets.UTF_8))) {
             writer.write("{\"freq\":{");
             boolean first = true;
             for (Map.Entry<String, Integer> entry : languageProfile.iterateGrams()) {

--- a/src/main/java/com/optimaize/langdetect/profiles/util/LanguageLister.java
+++ b/src/main/java/com/optimaize/langdetect/profiles/util/LanguageLister.java
@@ -20,8 +20,8 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
-import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 /**
  * This is just a utility to update the code with the existing languages.
@@ -43,17 +43,11 @@ class LanguageLister {
     }
 
     private static List<String> readFilesFromClassPathFolder(String resourceNameFolder) throws IOException {
-        List<String> files = new ArrayList<>();
         ClassLoader loader = LanguageLister.class.getClassLoader();
-        try (InputStream in = loader.getResourceAsStream(resourceNameFolder)) {
-            BufferedReader rdr = new BufferedReader(new InputStreamReader(in));
-            String line;
-            while ((line = rdr.readLine()) != null) {
-                files.add(line);
-            }
-            rdr.close();
+        try (InputStream in = loader.getResourceAsStream(resourceNameFolder);
+             BufferedReader rdr = new BufferedReader(new InputStreamReader(in))) {
+            return rdr.lines().collect(Collectors.toList());
         }
-        return files;
     }
 
 }

--- a/src/main/java/com/optimaize/langdetect/profiles/util/LanguageProfileValidator.java
+++ b/src/main/java/com/optimaize/langdetect/profiles/util/LanguageProfileValidator.java
@@ -16,7 +16,6 @@
 
 package com.optimaize.langdetect.profiles.util;
 
-import com.google.common.base.Predicate;
 import com.google.common.base.Splitter;
 import com.google.common.collect.Iterables;
 import com.optimaize.langdetect.DetectedLanguage;
@@ -129,12 +128,7 @@ public class LanguageProfileValidator {
      * @param isoString the ISO string of the LanguageProfile to be removed.
      */
     public LanguageProfileValidator removeLanguageProfile(final String isoString) {
-        Iterables.removeIf(this.languageProfiles, new Predicate<LanguageProfile>() {
-            @Override
-            public boolean apply(LanguageProfile languageProfile) {
-                return languageProfile.getLocale().getLanguage().equals(isoString);
-            }
-        });
+        Iterables.removeIf(this.languageProfiles, languageProfile -> languageProfile.getLocale().getLanguage().equals(isoString));
         return this;
     }
 
@@ -175,11 +169,7 @@ public class LanguageProfileValidator {
             List<DetectedLanguage> detectedLanguages = languageDetector.getProbabilities(testSample);
 
             try{
-                DetectedLanguage kResult = Iterables.find(detectedLanguages, new Predicate<DetectedLanguage>() {
-                    public boolean apply(DetectedLanguage language) {
-                        return language.getLocale().getLanguage().equals(languageProfile.getLocale().getLanguage());
-                    }
-                });
+                DetectedLanguage kResult = Iterables.find(detectedLanguages, language -> language.getLocale().getLanguage().equals(languageProfile.getLocale().getLanguage()));
 
                 probabilities.add(kResult.getProbability());
                 System.out.println("Probability: " + kResult.getProbability());

--- a/src/main/java/com/optimaize/langdetect/text/RemoveMinorityScriptsTextFilter.java
+++ b/src/main/java/com/optimaize/langdetect/text/RemoveMinorityScriptsTextFilter.java
@@ -16,8 +16,8 @@
 
 package com.optimaize.langdetect.text;
 
-import java.util.HashMap;
-import java.util.HashSet;
+import java.util.EnumMap;
+import java.util.EnumSet;
 import java.util.Map;
 import java.util.Set;
 
@@ -56,7 +56,7 @@ public class RemoveMinorityScriptsTextFilter implements TextFilter {
             return text.toString();
         } else {
             long most = findMost(counts);
-            Set<Character.UnicodeScript> toRemove = new HashSet<>();
+            Set<Character.UnicodeScript> toRemove = EnumSet.noneOf(Character.UnicodeScript.class);
             for (Map.Entry<Character.UnicodeScript, Long> entry : counts.entrySet()) {
                 if (entry.getValue()==most) continue;
                 double ratio = entry.getValue().doubleValue() / most;
@@ -103,7 +103,7 @@ public class RemoveMinorityScriptsTextFilter implements TextFilter {
     }
 
     private Map<Character.UnicodeScript, Long> countByScript(CharSequence text) {
-        Map<Character.UnicodeScript, Long> counter = new HashMap<>();
+        Map<Character.UnicodeScript, Long> counter = new EnumMap<>(Character.UnicodeScript.class);
         Character.UnicodeScript last = null;
         for (int i=0; i<text.length(); i++) {
             char c = text.charAt(i);


### PR DESCRIPTION
Covers the issue #76 . It can be maintained in a separate branch under the different artifact name (like `language-detector-java-8`) if the compatibility with the deprecated Java versions matters.

The commits include some language level changes as well. There are still some code places where Java 8  Stream API can be used. I can chnage those too.

Feel free to contact me and give any feedback.

Regards,
Vladimir