### PR TITLE
Improved mail regex

### DIFF
--- a/src/main/java/com/optimaize/langdetect/text/UrlTextFilter.java
+++ b/src/main/java/com/optimaize/langdetect/text/UrlTextFilter.java
@@ -26,7 +26,7 @@ import java.util.regex.Pattern;
 public class UrlTextFilter implements TextFilter {
 
     private static final Pattern URL_REGEX = Pattern.compile("https?://[-_.?&~;+=/#0-9A-Za-z]+");
-    private static final Pattern MAIL_REGEX = Pattern.compile("[-_.0-9A-Za-z]+@[-_0-9A-Za-z]+[-_.0-9A-Za-z]+");
+    private static final Pattern MAIL_REGEX = Pattern.compile("(?<![-+_.0-9A-Za-z])[-+_.0-9A-Za-z]+@[-0-9A-Za-z]+[-.0-9A-Za-z]+");
 
     private static final UrlTextFilter INSTANCE = new UrlTextFilter();
 


### PR DESCRIPTION
There are two changes here: 

1. Include `+` in the local part, and disallow `_` in the domain part. There are other characters that are allowed in the local part as well, but these are less common (https://en.wikipedia.org/wiki/Email_address). 
2. Optimise the pattern for the case of long contiguous strings with characters from the first character set, but without any `@` (or otherwise non-matching). 

Currently, the `replaceAll(" ")` on a string of ~100K characters from the set `[-_.0-9A-Za-z]` runs in ~1minute on modern hardware; adding a negative lookbehind with one of the characters from that set reduces this to a few milliseconds, and is functionally equivalent. (Consider the current pattern and a match from position `i` to `k`. If the character at `i-1` is in the character set, there would also be a match from `i-1` to `k`, which would already be replaced.)